### PR TITLE
Nick balance changes

### DIFF
--- a/XPMod/Binds/Bind1/S/Bind1_Nick.sp
+++ b/XPMod/Binds/Bind1/S/Bind1_Nick.sp
@@ -145,7 +145,7 @@ NickGamblingProblemRollTheDice(int iClient)
 		}
 		case 7: //Gain a self revive (only once per round)
 		{
-			if(g_bNickGambedSelfReviveThisRound[iClient] == true)
+			if(g_bNickGambedSelfReviveUses > 1)
 			{
 				NickGamblingProblemRollTheDice(iClient);
 				return;
@@ -155,7 +155,7 @@ NickGamblingProblemRollTheDice(int iClient)
 			PrintToChatAll("\x03[XPMod] \x05%N found a self revive stashed away.", iClient);
 
 			g_iSelfRevives[iClient]++;
-			g_bNickGambedSelfReviveThisRound[iClient] = true;
+			g_bNickGambedSelfReviveUses++;
 		}
 		case 8: //Get three more times to Gamble
 		{
@@ -191,21 +191,28 @@ NickGamblingProblemRollTheDice(int iClient)
 		}
 		case 11: //Revival; Return to maximum health, even when incaped
 		{
+			if(g_bNickGambedDivineInterventionUses > 1)
+			{
+				NickGamblingProblemRollTheDice(iClient);
+				return;
+			}
 			if(IsClientGrappled(iClient) == false)
 			{
+				g_bNickGambedDivineInterventionUses++;
 				CreateTimer(0.1, TimerApplyDivineIntervention, iClient, TIMER_FLAG_NO_MAPCHANGE);
 			}
 			else
 			{
+				g_bNickGambedDivineInterventionUses++;
 				g_bDivineInterventionQueued[iClient] = true;
 				PrintToChat(iClient, "\x03[XPMod] \x05Divine intervention will be applied when you break free!");
 			}
 		}
 		case 12: //Gain more bind2s
 		{
-			if (g_bNickAlreadyGivenMoreBind2s[iClient] == false)
+			if (g_bNickAlreadyGivenMoreBind2s == false)
 			{
-				g_bNickAlreadyGivenMoreBind2s[iClient] = true;
+				g_bNickAlreadyGivenMoreBind2s = true;
 				PrintHintText(iClient,"Rolled a 12\nA night of partying left you wanting more.");
 				PrintToChatAll("\x03[XPMod] \x05%N feels ready for more! +3 to Bind2!", iClient);
 				g_iClientBindUses_2[iClient] -= 3;

--- a/XPMod/GlobalVariables/Survivors.sp
+++ b/XPMod/GlobalVariables/Survivors.sp
@@ -262,6 +262,8 @@ new g_iTempHealthBeforeUsingHealthBoostSlotItem[MAXPLAYERS + 1];
 #define ELLIS_ROF_PISTOLS                1.5
 
 //Nicks Stuff
+#define NICK_REVIVE_COOLDOWN         10.0
+#define NICK_HEAL_COOLDOWN           5.0
 new bool:g_bNickIsStealingLife[MAXPLAYERS + 1][MAXPLAYERS + 1];	//g_bNickIsStealingLife[victim][attacker]
 new g_iNickStealingLifeRuntimes[MAXPLAYERS + 1];
 new g_iNickResurrectUses = 0;
@@ -272,7 +274,7 @@ new String:g_strNickSecondarySlot1[512];
 new g_iNickCurrentSecondarySlot[MAXPLAYERS + 1];
 new g_iNickSecondarySavedClipSlot1[MAXPLAYERS + 1];
 new g_iNickSecondarySavedClipSlot2[MAXPLAYERS + 1];
-#define NICK_HEAL_PISTOL_GIVE       2
+#define NICK_HEAL_PISTOL_GIVE       1
 #define NICK_HEAL_PISTOL_TAKE       1
 #define NICK_HEAL_MAGNUM_GIVE       7
 #define NICK_HEAL_MAGNUM_TAKE       3
@@ -282,7 +284,7 @@ new bool:g_bRamboModeActive[MAXPLAYERS + 1];
 //new g_iNickDesperateMeasuresDeathStack;
 //new g_iNickDesperateMeasuresIncapStack;
 new bool:g_bDivineInterventionQueued[MAXPLAYERS + 1];
-new bool:g_bNickAlreadyGivenMoreBind2s[MAXPLAYERS + 1];
+new bool:g_bNickAlreadyGivenMoreBind2s = false;
 new g_iNickDesperateMeasuresStack;
 new g_iRamboWeaponID[MAXPLAYERS + 1];
 //g_bIsNickInSecondaryCycle
@@ -299,8 +301,11 @@ new g_iNickPrimarySavedAmmo[MAXPLAYERS + 1];
 new g_iNickUpgradeAmmo[MAXPLAYERS + 1];
 new String:g_strNickUpgradeType[32];
 new bool:g_bNickStoresDroppedPistolAmmo[MAXPLAYERS + 1] = {false, ...};
-bool g_bNickGambedSelfReviveThisRound[MAXPLAYERS + 1] = {false, ...}; 
+new g_bNickGambedSelfReviveUses = 0;
+new g_bNickGambedDivineInterventionUses = 0;
 bool g_bNickGambleLockedBinds[MAXPLAYERS + 1] = {false, ...};
+bool g_bNickReviveCooldown;
+bool g_bNickHealCooldown;
 
 // Louis
 #define LOUIS_TELEPORT_TOTAL_CHARGES                    3

--- a/XPMod/Misc/Admin_Commands.sp
+++ b/XPMod/Misc/Admin_Commands.sp
@@ -100,7 +100,7 @@ int ResurrectPlayer(int iTarget, int iClient)
 	WriteParticle(iTarget, "nick_ulti_resurrect_soul", 0.0, 25.0);
 	WriteParticle(iTarget, "nick_ulti_resurrect_trail", 0.0, 25.0);
 
-	SetPlayerHealth(iTarget, -1, 50);
+	SetPlayerHealth(iTarget, -1, 85);
 	SetAppropriateMaxHealthForPlayer(iTarget, false);
 
 	// Update Nicks Desperate Measures Stacks

--- a/XPMod/Misc/MovementSpeed.sp
+++ b/XPMod/Misc/MovementSpeed.sp
@@ -151,8 +151,8 @@ SetClientSpeedNick(iClient, &Float:fSpeed)
 	if (g_iNickDesperateMeasuresStack > 0)
 	{
 		fSpeed += g_iNickDesperateMeasuresStack >= 3 ? 
-			(3 * (g_iDesperateLevel[iClient] * 0.02)) : 
-			(g_iNickDesperateMeasuresStack * (g_iDesperateLevel[iClient] * 0.02));
+			(3 * (g_iDesperateLevel[iClient] * 0.01)) : 
+			(g_iNickDesperateMeasuresStack * (g_iDesperateLevel[iClient] * 0.01));
 	}
 	
 	//PrintToChat(iClient, "SetClientSpeedNick: %f", fSpeed);

--- a/XPMod/Misc/ResetVariables.sp
+++ b/XPMod/Misc/ResetVariables.sp
@@ -45,7 +45,10 @@ void ResetAllVariablesForRound()
 	SetConVarInt(FindConVar("first_aid_kit_use_duration"), 5);
 	SetConVarInt(FindConVar("defibrillator_use_duration"), 3);
 	g_bCommonInfectedDoMoreDamage = false;
+	g_bNickAlreadyGivenMoreBind2s = false;
 	g_iNickResurrectUses = 0;
+	g_bNickGambedSelfReviveUses = 0;
+	g_bNickGambedDivineInterventionUses = 0;
 	g_iHighestLeadLevel = 0;
 	g_iCoachTeamHealthStack = 0;
 	g_iCrawlSpeedMultiplier = 0;
@@ -195,12 +198,12 @@ void ResetClientVariablesForRound(int iClient)
 	//Nick
 	g_bNickIsGettingBeatenUp[iClient] = false;
 	g_bDivineInterventionQueued[iClient] = false;
-	g_bNickAlreadyGivenMoreBind2s[iClient] = false;
 	g_iNickDesperateMeasuresStack = 0;
 	g_iRamboWeaponID[iClient] = -1;
 	g_iNickPistolSwaps[iClient] = 0;
-	g_bNickGambedSelfReviveThisRound[iClient] = false;
 	g_bNickGambleLockedBinds[iClient] = false;
+	g_bNickReviveCooldown = false;
+	g_bNickHealCooldown = false;
 
 	//Louis
 	g_bLouisLaserModeActivated[iClient] = true;

--- a/XPMod/Talents/S/Talents_Nick.sp
+++ b/XPMod/Talents/S/Talents_Nick.sp
@@ -46,7 +46,7 @@ void SetPlayerTalentMaxHealth_Nick(int iClient, bool bFillInHealthGap = true)
 	
 	// Give nick more max health for each kit used, but cap it at +100 HP.
 	SetPlayerMaxHealth(iClient,
-		100 + 
+		115 + 
 		(g_iKitsUsed * (g_iSwindlerLevel[iClient] * 3)) < 200 ? 
 			100 + (g_iKitsUsed * (g_iSwindlerLevel[iClient] * 3)) + (g_iCoachTeamHealthStack * 5) : 
 			200 + (g_iCoachTeamHealthStack * 5),
@@ -571,7 +571,7 @@ EventsHurt_AttackerNick(Handle:hEvent, iAttacker, iVictim)
 			new hp = GetPlayerHealth(iVictim);
 			new dmg = GetEventInt(hEvent,"dmg_health");
 
-			dmg = RoundToNearest(dmg * (g_iMagnumLevel[iAttacker] * 1.00));
+			dmg = RoundToNearest(dmg * (g_iMagnumLevel[iAttacker] * 0.65));
 			dmg = CalculateDamageTakenForVictimTalents(iVictim, dmg, weaponclass);
 
 			//PrintToChat(iAttacker, "your doing %d extra magnum damage", dmg);
@@ -582,7 +582,7 @@ EventsHurt_AttackerNick(Handle:hEvent, iAttacker, iVictim)
 			new hp = GetPlayerHealth(iVictim);
 			new dmg = GetEventInt(hEvent,"dmg_health");
 
-			dmg = RoundToNearest(dmg * (g_iRiskyLevel[iAttacker] * 0.2));
+			dmg = RoundToNearest(dmg * (g_iRiskyLevel[iAttacker] * 0.13));
 			dmg = CalculateDamageTakenForVictimTalents(iVictim, dmg, weaponclass);
 
 			//PrintToChat(iAttacker, "your doing %d extra damage", dmg);
@@ -938,6 +938,10 @@ JebusHandMenuHandler(Menu menu, MenuAction:action, iClient, itemNum)
 		{
 			case 0: //Heal Every Teammate
 			{
+				if(g_bNickHealCooldown == true) {
+					PrintHintText(iClient, "Global cooldown triggered. You must wait 5 seconds to use Heal again.");
+					return;
+				}
 				decl currentHP;
 				decl maxHP;
 
@@ -951,10 +955,12 @@ JebusHandMenuHandler(Menu menu, MenuAction:action, iClient, itemNum)
 							maxHP = GetPlayerMaxHealth(i);
 							//PrintToChatAll("max health for %N is %d", i, maxHP);
 							PrintHintText(i, "You have been partially healed by %N", iClient);
-							if((currentHP + (g_iDesperateLevel[iClient] * 4)) >= maxHP)
+							g_bNickHealCooldown = true;	
+							CreateTimer(NICK_HEAL_COOLDOWN, TimerReEnableHealBind, iClient, TIMER_FLAG_NO_MAPCHANGE);
+							if((currentHP + (g_iDesperateLevel[iClient] * 5)) >= maxHP)
 								SetPlayerHealth(i, -1, maxHP);
 							else
-								SetPlayerHealth(i, -1, currentHP + (g_iDesperateLevel[iClient] * 4));
+								SetPlayerHealth(i, -1, currentHP + (g_iDesperateLevel[iClient] * 5));
 						}
 						// Handle Ellis
 						if(g_iOverLevel[i] > 0)
@@ -1002,6 +1008,10 @@ JebusHandMenuHandler(Menu menu, MenuAction:action, iClient, itemNum)
 			}
 			case 1: //Revive Downed Teammate
 			{
+				if(g_bNickReviveCooldown == true) {
+					PrintHintText(iClient,"Global cooldown triggered. You must wait 10 seconds to Revive Teammate again.");
+					return;
+				}
 				if(g_iClientBindUses_2[iClient] < 2)
 				{
 					new foundvalident = 0;
@@ -1021,6 +1031,8 @@ JebusHandMenuHandler(Menu menu, MenuAction:action, iClient, itemNum)
 								WriteParticle(i, "nick_ulti_revive", 0.0, 15.0);
 								
 								foundvalident++;
+								g_bNickReviveCooldown = true;
+								CreateTimer(NICK_REVIVE_COOLDOWN, TimerReEnableReviveBind, iClient, TIMER_FLAG_NO_MAPCHANGE);
 								switch(g_iClientBindUses_2[iClient])
 								{
 									case 1:
@@ -1054,6 +1066,8 @@ JebusHandMenuHandler(Menu menu, MenuAction:action, iClient, itemNum)
 								WriteParticle(i, "nick_ulti_revive", 0.0, 15.0);
 								
 								foundvalident++;
+								g_bNickReviveCooldown = true;
+								CreateTimer(NICK_REVIVE_COOLDOWN, TimerReEnableReviveBind, iClient, TIMER_FLAG_NO_MAPCHANGE);
 								switch(g_iClientBindUses_2[iClient])
 								{
 									case 1:

--- a/XPMod/Timers/S/Timers_Nick.sp
+++ b/XPMod/Timers/S/Timers_Nick.sp
@@ -96,6 +96,14 @@ Action:TimerReEnableBindsNick(Handle:timer, any:iClient)
 	g_bNickGambleLockedBinds[iClient] = false;
 	return Plugin_Stop;
 }
+Action:TimerReEnableReviveBind(Handle:timer, any:iClient) {
+	g_bNickReviveCooldown = false;
+	return Plugin_Stop;
+}
+Action:TimerReEnableHealBind(Handle:timer, any:iClient) {
+	g_bNickHealCooldown = false;
+	return Plugin_Stop;
+}
 
 Action:TimerLifeStealing(Handle:timer, any:pack)
 {


### PR DESCRIPTION
- Damage Reduction: Decreased damage for pistols and magnum by 35%.
- Global Cooldown for using Revive Bind2: 10 seconds
- Global Cooldown for using Healing Bind2: 5 seconds
- Resurrect base health to 85
- Decreased incap/dead speed bonus by 50% 
- Fresh life and Self Revive from gambles limited to twice globally.
- Extra +3 gamble limited to once globally. 
- Nick starts with 115 health
- Increase "Heal Teammate" by an additional 5 HP
- Dual Pistols heal 1hp and lose 1hp 