### PR TITLE
Bill balance update 

### DIFF
--- a/XPMod/Events/Events_Survivors.sp
+++ b/XPMod/Events/Events_Survivors.sp
@@ -468,11 +468,12 @@ Action:Event_PlayerIncap(Handle:hEvent, String:Event_name[], bool:dontBroadcast)
 					if(g_bIsClientDown[i] == false)
 					{
 						new currentHP = GetPlayerHealth(i);
-						if((currentHP + (g_iDiehardLevel[i] * 6)) < (100 + (g_iWillLevel[i]*5) + (g_iDiehardLevel[i]*15)))
-							SetPlayerHealth(i, -1, currentHP + (g_iDiehardLevel[i] * 6));
+						if((currentHP + (g_iDiehardLevel[i] * 9)) < (100 + (g_iWillLevel[i]*5) + (g_iDiehardLevel[i]*15)))
+							SetPlayerHealth(i, -1, currentHP + (g_iDiehardLevel[i] * 9));
 						else
 							SetPlayerHealth(i, -1, 100 + (g_iWillLevel[i]*5) + (g_iDiehardLevel[i]*15));
-						PrintHintText(i, "A teammate has fallen, you gain %d health.", (g_iDiehardLevel[i] * 6));
+						PrintHintText(i, "A teammate has fallen, you gain %d health and +%dhp to your healing pool", (g_iDiehardLevel[i] * 9), (g_iDiehardLevel[i] * 5));
+						g_iBillsTeamHealthPool+=(g_iDiehardLevel[i] * 5);
 					}
 				}
 			}

--- a/XPMod/Menus/S/Menu_Bill.sp
+++ b/XPMod/Menus/S/Menu_Bill.sp
@@ -253,8 +253,8 @@ Action:DiehardMenuDraw(iClient)
 		%s					Die Hard(Level %d):\
 		\n \
 		\n+15 max health per level\
-		\nRegen 6 health when ally incaps per level\
-		\n \
+		\nRegen 9 health when ally incaps per level\
+		\n+5hp when ally incaps per level\
 		\n \
 		\n		Bind 1: Improvised Explosives\
 		\n			+1 use every other level\

--- a/XPMod/Menus/S/Menu_Bill.sp
+++ b/XPMod/Menus/S/Menu_Bill.sp
@@ -254,7 +254,7 @@ Action:DiehardMenuDraw(iClient)
 		\n \
 		\n+15 max health per level\
 		\nRegen 9 health when ally incaps per level\
-		\n+5hp when ally incaps per level\
+		\n+5hp to healing pool when ally incaps per level\
 		\n \
 		\n		Bind 1: Improvised Explosives\
 		\n			+1 use every other level\


### PR DESCRIPTION
+ Increase health gain from 6hp to 9hp per level when a survivor goes down.
+ When a survivor goes down, add 5hp per level to the healing pool. 